### PR TITLE
test: load dotenv on conftest module level

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,10 +18,11 @@ from pharia_inference_sdk.core import (
     Pharia1ChatModel,
 )
 
+load_dotenv()
+
 
 @fixture(scope="session")
 def token() -> str:
-    load_dotenv()
     token = getenv("AA_TOKEN")
     assert isinstance(token, str)
     return token


### PR DESCRIPTION
- when running the tests in parallel the dotenv sometimes would not be correctly loaded from the dotenv, this most likely happens because of some dependency of the AA_TOKEN that does not depend on the fixture `token`